### PR TITLE
Change individual to DevDocs team as Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-@dacharyc @davidhou17
+@devdocs @davidhou17
 
-/.github/ @dacharyc
+/.github/ @devdocs


### PR DESCRIPTION
The DevDocs team would prefer making the team a codeowner instead of an individual for visibility and shared responsibility.